### PR TITLE
fix: replace wrong attribute in XCharter fontspec

### DIFF
--- a/chicv.cls
+++ b/chicv.cls
@@ -71,12 +71,13 @@
     \setmainfont{XCharter}[ % in case XCharter is not installed
         Path = ./fonts/,
         Extension = .otf,
+        UprightFont = XCharter-Roman,
         BoldFont = XCharter-Bold,
         ItalicFont = XCharter-Italic,
         BoldItalicFont = XCharter-BoldItalic,
-        BoldSlantedFont = XCharter-BoldSlanted,
         SlantedFont = XCharter-Slanted,
-        RomanFont = XCharter-Roman,
+        BoldSlantedFont = XCharter-BoldSlanted,
+        SmallCapsFeatures =  {Letters=SmallCaps}
     ]
 }
 


### PR DESCRIPTION
I tried to compile resume.tex by myself. However, I met an error.
```
mktextfm: `mf-nowin -progname=mf \mode:=ljfour; mag:=1; ; nonstopmode; input XCharter' failed to make XCharter.tfm.
kpathsea: Appending font creation commands to missfont.log.

(/usr/share/texmf-dist/tex/latex/xcharter/XCharter.fontspec)

! LaTeX3 Error: The key 'fontspec-opentype/RomanFont' is unknown and is being
(LaTeX3)        ignored.

For immediate help type H <return>.
 ...                                              
                                                  
l.81 }
```
It looks like that an attribute in XCharter fontspec is wrong.

I noticed that XCharter package provides an official fontspec to allow users to use the font directly. So, I copied the content and made it available in this PR. Now it works fine.

One thing I'm still worried about is my texlive distribution doesn't think that XCharter font is available even if XCharter package is installed locally. I think the reason is that xelatex can only find fonts shipped with tex distribution by name, like "Xcharter-Bold.otf". Xelatex can also find a "general" font like "XCharter" if there is a fontspec file, while IfFontExistsTF cannot. If I want to use the system font XCharter, I have to link those otf files to my global font directory to make them available to the whole system.

I think a better way is to just use XCharter font but not check availability, because TexLive and MikTeX both ship XCharter package. I'm not sure whether I should open a new issue.

Some system information: `This is XeTeX, Version 3.141592653-2.6-0.999994 (TeX Live 2022/Arch Linux) (preloaded format=xelatex)`.

Thanks for creating this awesome template!